### PR TITLE
Update setInterval to use requestAnimationFrame for better performance

### DIFF
--- a/source/raw_assets/scramble-letters.user.js
+++ b/source/raw_assets/scramble-letters.user.js
@@ -11,7 +11,7 @@
 // @nocompat     Chrome
 // ==/UserScript==
 
-(function() {
+(function () {
 
   'use strict';
 
@@ -19,19 +19,22 @@
   function getTextNodes() {
     var nodes = [];
     var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false);
-    while(walker.nextNode()) {
+    while (walker.nextNode()) {
       nodes.push(walker.currentNode);
     }
     return nodes;
   }
   var textNodes = getTextNodes();
 
-  // iterate over each text node and mess up their values
-  setInterval(function() {
+  var iterateFunction = function () {
     for (var i = 0; i < textNodes.length; i++) {
       textNodes[i].nodeValue = messUpWords(textNodes[i].nodeValue);
     }
-  }, 10);
+    window.requestAnimationFrame(iterateFunction);
+  }
+
+  // iterate over each text node and mess up their values
+  window.requestAnimationFrame(iterateFunction);
 
   // parse words out of a string and mess them up
   function messUpWords(str) {
@@ -58,7 +61,7 @@
     var scrambledWord = '';
 
     // if it's a small word or ~randomness~, don't scramble it
-    if (word.length < 3 || Math.random() > 1/10) {
+    if (word.length < 3 || Math.random() > 1 / 10) {
       return word;
     }
 

--- a/source/raw_assets/scramble-letters.user.js
+++ b/source/raw_assets/scramble-letters.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Scramble letters
 // @namespace    https://github.com/alphagov/accessibility-personas
-// @version      1.0
+// @version      1.0.1
 // @license      MIT
 // @author       Victor Widell, Andrew Kennedy [https://github.com/geon/geon.github.com/pull/3] and Crown Copyright (Government Digital Service)
 // @description  Scramble letters within words to simulate some form of dyslexia


### PR DESCRIPTION
Removed the use of setInterval which was trying to execute the function 100 times per-second leading to page lagging and high CPU usage. Using requestAnimationFrame will allow the browser to schedule the next function execution to when it is best for the thread. In most cases this will be 60 times per second (to match the standard refresh rate). The browser will be allowed to drop frames if it is under heavy-load.

For more information on requestAnimationFrame see [here](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame).

Image showing the CPU usage using setInterval (single snapshot)
![setInterval-tab-in-view](https://user-images.githubusercontent.com/1223960/56591074-060b6300-65e0-11e9-910b-a632e7471543.png)

Image showing the CPU usage using requestAnimationFrame (single snapshot)
![RAF-enabled-tab-in-view](https://user-images.githubusercontent.com/1223960/56591102-0e639e00-65e0-11e9-9e8e-5c882e6848ed.png)

CPU usage should be reduced and the browser should be allowed to prioritise other tasks if required to. Should help with the performance issues mentioned in [Issue 2](https://github.com/alphagov/accessibility-personas/issues/2)