### PR TITLE
Update outdated link to Tech Docs documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These pages include:
 
 ## Running the tool
 
-The tool is based on the [tech docs template](https://alphagov.github.io/tech-docs-manual/).
+The tool is based on the [tech docs template](https://tdt-documentation.london.cloudapps.digital/).
 Read more in depth documentation on there.
 
 But in short...


### PR DESCRIPTION
As mentioned in #5, the old Tech Docs documentation is going to retire soon. This updates the link in the README to the new URL.