### PR TITLE
Small improvements for a couple of tasks

### DIFF
--- a/source/_example_snippets/form_fields_no_label/_bad.erb
+++ b/source/_example_snippets/form_fields_no_label/_bad.erb
@@ -2,7 +2,7 @@
   <div class="form-label-bold" <% if right_align_inputs %>style="float: left;"<% end %>>
     What year is it?
   </div>
-  <input class="form-control form-control-1-4" id="year" name="year" type="text" <% if right_align_inputs %>style="float: right;"<% end %> />
+  <input class="form-control form-control-1-4" id="year" name="year" type="text" autocomplete="off" <% if right_align_inputs %>style="float: right;"<% end %> />
 </div>
 
 <div class="form-group">

--- a/source/_example_snippets/form_fields_no_label/_good.erb
+++ b/source/_example_snippets/form_fields_no_label/_good.erb
@@ -2,7 +2,7 @@
   <label class="form-label-bold" for="year">
     What year is it?
   </label>
-  <input class="form-control form-control-1-4" id="year" name="year" type="text" />
+  <input class="form-control form-control-1-4" id="year" name="year" type="text" autocomplete="off" />
 </div>
 
 <div class="form-group">

--- a/source/_example_snippets/large_blocks_of_text/_bad.erb
+++ b/source/_example_snippets/large_blocks_of_text/_bad.erb
@@ -6,10 +6,9 @@
   </div>
 <% end %>
 
-The Prime Minister is head of the UK government. They are ultimately responsible for all policy and decisions. They oversee the operation of the Civil Service and government agencies, appoint members of the government and are the principal government figure in the House of Commons. The Prime Minister is The Rt Hon Theresa May MP. [Read more about the Prime Minister's Office, 10 Downing Street](/fake.html).
+The Prime Minister is head of the UK government. They are ultimately responsible for all policy and decisions. They oversee the operation of the Civil Service and government agencies, appoint members of the government and are the principal government figure in the House of Commons. The Prime Minister is The Rt Hon Theresa May MP.
 
-The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government. [See who is in the Cabinet](/fake.html).
+The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.
 
 1 Prime Minister + 22 Cabinet ministers + 98 Other ministers = 121 Total ministers.
 Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.
-[See full list of ministers](/fake.html).

--- a/source/_example_snippets/large_blocks_of_text/_good.erb
+++ b/source/_example_snippets/large_blocks_of_text/_good.erb
@@ -16,14 +16,10 @@ The Prime Minister is head of the UK government. They are ultimately responsible
 
 The Prime Minister is The Rt Hon Theresa May MP.
 
-[Read more about the Prime Minister's Office, 10 Downing Street](/fake.html).
-
 
 ### The Cabinet
 
 The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.
-
-[See who is in the Cabinet](/fake.html).
 
 
 ### Ministers
@@ -34,5 +30,3 @@ The Cabinet is made up of the senior members of government. Every week during Pa
 = 121 Total ministers
 
 Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.
-
-[See full list of ministers](/fake.html).

--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -180,6 +180,16 @@ button.blue {
   display: inline-block;
 }
 
+/*
+  This fixes an odd behaviour with Claudia's bad example page:
+  Although we intentionally removed the labels before the form fields,
+  there is still a clickable area which focuses on the input,
+  which leads to people finding the input quicker than they otherwise would.
+*/
+.form-group:after {
+  width: 0;
+}
+
 /* ____________ documentation pages ____________ */
 
 img.profile {

--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -203,12 +203,3 @@ img.profile {
     height: 256px;
   }
 }
-
-/* the "Dyslexia Friendly" Chrome extension creates a ruler on the page
-   which overlaps the text on some pages like ours so that links cannot be clicked on;
-   this makes the ruler a bit smaller so links work again;
-   reported and can be removed again after this has been fixed:
-   https://github.com/javoire/dyslexia-friendly/issues/18 */
-#ruler {
-  pointer-events: none;
-}


### PR DESCRIPTION
During persona training we found that some tasks are not as effective:

* People doing Claudia's task are supposed to have difficulties finding the input fields. There is a weird glitch which means people find it quicker than anticipated. This fixes that.
* People doing Claudia's or Ron's tasks often click on the links within the text. As they don't have anything to do with the task, I've removed them.
* People can get confused if forms had already been filled in previously and they get the autocomplete option. So, I've removed that option via setting the `autocomplete` attribute.
