### PR TITLE
Change Chris' simulation

### DIFF
--- a/source/raw_assets/remove-cursor.user.css
+++ b/source/raw_assets/remove-cursor.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name         Remove cursor
 @namespace    https://github.com/alphagov/accessibility-personas
-@version      1.0.0
+@version      1.0.1
 @license      MIT
 @author       Crown Copyright (Government Digital Service)
 @description  Remove the cursor to make it harder to use the mouse or touchpad
@@ -10,4 +10,5 @@
 
 * {
   cursor: none !important;
+  pointer-events: none !important;
 }

--- a/source/setup/chrome.html.md
+++ b/source/setup/chrome.html.md
@@ -25,11 +25,6 @@ Instead of using the ChromeVox version that comes with Chrome OS, install the [C
 Note: This will have different shortcuts than the Chrome OS version, for example, instead of "Search + Arrow Right/Left" to read the next/previous text, use "Shift + Alt + Arrow Right/Left" on Windwos and "Cmd + Ctrl + Arrow Right/Left" on Mac
 
 
-## Chris
-
-Instead of disabling the touchpad, install the [Stylus extension](https://chrome.google.com/webstore/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne) and open [remove-cursor.user.css](raw_assets/remove-cursor.user.css) in the browser; when Stylus opens, click the "Install style" button (once per device)
-
-
 ## Simone
 
 Instead of using Select-to-Speak and the nOverlay extension, install the [ClaroRead extension](https://chrome.google.com/webstore/detail/claroread-chrome/ifgehbglgmidafhhdcopacejknmcmhcd)

--- a/source/setup/chromebook.html.md
+++ b/source/setup/chromebook.html.md
@@ -105,9 +105,9 @@ Chris
 
 ### Simulation
 
-Enable "debugging keyboard shortcuts" in chrome://flags/#ash-debug-shortcuts (and restart) (once per device)
+Install extension: [Stylus](https://chrome.google.com/webstore/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne)
 
-Toggle the touchpad off with Search + Shift + P
+Open [remove-cursor.user.css](raw_assets/remove-cursor.user.css) in the browser; when Stylus opens, click the "Install style" button (once per device)
 
 ### Tools
 


### PR DESCRIPTION
People often get stuck when they switch to the Chris persona because they don't know how to get to the selection of profiles to switch to a different profile. And they forget they could use the touchscreen.

This changes the simulation to the already existing userstyle instead.
That means people can use the cursor outside the browser, it is only hidden in the browser.