### PR TITLE
Fix heavy blur not working on non-secure websites

### DIFF
--- a/source/raw_assets/heavy-blur.user.css
+++ b/source/raw_assets/heavy-blur.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name         Heavy blur
 @namespace    https://github.com/alphagov/accessibility-personas
-@version      1.0.0
+@version      1.0.1
 @license      MIT
 @author       Crown Copyright (Government Digital Service)
 @description  Blur the screen heavily to simulate some form of blindness (makes text unreadable)
@@ -9,7 +9,7 @@
 ==/UserStyle== */
 
 /* apply to every website and page except to https://alphagov.github.io/accessibility-personas/ashleigh/ */
-@-moz-document regexp("http?s:\/\/(?!alphagov\.github\.io\/accessibility\-personas\/ashleigh\/$).*") {
+@-moz-document regexp("https?:\/\/(?!alphagov\.github\.io\/accessibility\-personas\/ashleigh\/$).*") {
   body {
     filter: blur(7px) contrast(70%);
   }


### PR DESCRIPTION
The regex that is used to make an exception to the heavy blurring for Ashleigh is incorrect and is not matching HTTP websites.

Today we had visitors who tested their HTTP-only website with Ashleigh's profile and the blurring wasn't showing.