### PR TITLE
Make pagination links easier to see for Ron

### DIFF
--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -21,7 +21,7 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
 
 .pagination.good a {
   padding: .7em 1em;
-  border: 1px solid;
+  border: 2px solid;
   margin-right: .5em;
 }
 


### PR DESCRIPTION
The exercise with the pagination was created for Ron. The pagination links are easier to click on in the fixed example. But it's difficult to see for Ron that the click area has been increased because the border disappears due to his bad eyesight (or simulation thereof).

This fixes that by making the border a bit thicker.

Before it was harder to see the border.
<img width="274" alt="" src="https://user-images.githubusercontent.com/108893/73296329-6c718180-4201-11ea-8bc1-331347004cbc.png">

Now it's easier to see the border.
<img width="273" alt="" src="https://user-images.githubusercontent.com/108893/73296355-785d4380-4201-11ea-9978-5782415e03b0.png">

