### PR TITLE
Clarify things for Chrome browser setup

### DIFF
--- a/source/_example_snippets/form_fields_no_label/_bad.erb
+++ b/source/_example_snippets/form_fields_no_label/_bad.erb
@@ -1,16 +1,16 @@
 <div class="govuk-form-group">
-  <div class="govuk-label" <% if right_align_inputs %>style="float: left;"<% end %>>
+  <div class="govuk-label">
     What year is it?
   </div>
-  <input class="govuk-input govuk-!-width-one-quarter" id="year" name="year" type="text" autocomplete="off" <% if right_align_inputs %>style="float: right;"<% end %>/>
+  <input class="govuk-input govuk-!-width-one-quarter" id="year" name="year" type="text" autocomplete="off" />
 </div>
 
 <div class="govuk-form-group">
   <fieldset class="govuk-fieldset">
-    <div class="govuk-fieldset__legend" <% if right_align_inputs %>style="float: left;"<% end %>>
+    <div class="govuk-fieldset__legend">
       Are you a human?
     </div>
-    <div class="govuk-radios govuk-radios--inline" <% if right_align_inputs %>style="float: right;"<% end %>>
+    <div class="govuk-radios govuk-radios--inline">
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="humantest-yes" name="humantest" type="radio" value="yes">
         <label class="govuk-label govuk-radios__label" for="wrong-id">

--- a/source/_example_snippets/large_blocks_of_text/_bad.erb
+++ b/source/_example_snippets/large_blocks_of_text/_bad.erb
@@ -12,5 +12,5 @@ The Prime Minister is head of the UK government. They are ultimately responsible
 
 The Cabinet is made up of the senior members of government. Every week during Parliament, members of the Cabinet (Secretaries of State from all departments and some other ministers) meet to discuss the most important issues for the government.
 
-1 Prime Minister + 22 Cabinet ministers + 94 Other ministers = 117 Total ministers.
+1 Prime Minister + 20 Cabinet ministers + 97 Other ministers = 118 Total ministers.
 Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.

--- a/source/_example_snippets/large_blocks_of_text/_good.erb
+++ b/source/_example_snippets/large_blocks_of_text/_good.erb
@@ -25,8 +25,8 @@ The Cabinet is made up of the senior members of government. Every week during Pa
 ### Ministers
 
 1 Prime Minister<br />
-+ 22 Cabinet ministers<br />
-+ 94 Other ministers<br />
-= 117 Total ministers
++ 20 Cabinet ministers<br />
++ 97 Other ministers<br />
+= 118 Total ministers
 
 Ministers are chosen by the Prime Minister from the members of the House of Commons and House of Lords. They are responsible for the actions, successes and failures of their departments.

--- a/source/ashleigh/bad.html.md.erb
+++ b/source/ashleigh/bad.html.md.erb
@@ -14,7 +14,7 @@ title: Issues for Ashleigh
 # <%= current_page.data.title %>
 
 <form action="<%= url_for '/fake.html' %>" method="get">
-  <%= partial "/_example_snippets/form_fields_no_label/bad", locals: { right_align_inputs: false } %>
+  <%= partial "/_example_snippets/form_fields_no_label/bad" %>
 
   <button class="govuk-button" data-module="govuk-button">
     Send

--- a/source/ashleigh/index.html.md
+++ b/source/ashleigh/index.html.md
@@ -25,7 +25,8 @@ Screen reader quick guide:
 
 * press 'Tab' to go to the next link or form element
 * press 'Shift + Tab' to go back to the previous link or form element
-* press 'Search + Arrow Right/Left' to read text in between those
+* press 'Search + Arrow Right/Left' to read text in between those (or 'Shift + Alt + Arrow Right/Left' on Windows or 'Cmd + Ctrl + Arrow Right/Left' on Mac)
+* [learn more shortcuts](https://www.chromevox.com/keyboard_shortcuts.html)
 
 
 ## Training tasks

--- a/source/chris/index.html.md
+++ b/source/chris/index.html.md
@@ -21,11 +21,30 @@ More about the [persona on GOV.UK](https://www.gov.uk/government/publications/un
 
 ## Chromebook help
 
-Navigate with the tab key. Navigate back with 'Shift + Tab'.
-If you're stuck, use the touchscreen. 'Ctrl + Alt + /' shows keyboard shortcuts.
+Navigate with the keyboard:
 
-Start using voice control (only in the browser) by saying "wake up". Other commands: "click" (and then follow the on-screen instructions, often saying a number), "scroll down", "scroll up", "help".
-If it doesn’t work, restart the extension.
+* press 'Tab' to go to the next link or form element
+* press 'Shift + Tab' to go back to the previous link or form element
+* press arrow keys to move between radio buttons
+* press 'Space' to select radio button or checkbox
+* press 'Enter' to follow a link or submit a form
+* press 'Esc' to close things
+
+If you're stuck, use the touchscreen.<br />
+'Ctrl + Alt + /' shows keyboard shortcuts (only on a Chromebook).
+
+Start voice control:
+
+* it might already be running, say a command (see below) to find out, there should be a round microphone icon in the bottom left corner
+* if it's running but 'asleep', say "wake up"
+* if it's not running, click on the 'Handsfree for Web' icon <img src="https://www.handsfreeforweb.com/img/favicon-16x16.png" style="width: 16px; height: 16px;" alt="" /> next to the address bar
+* if it's unresponsive, restart the extension
+
+Use voice control commands (only in the browser):
+
+* say "click" and then follow the on-screen instructions, often saying a number
+* say "scroll down" and "scroll up" to scroll the page
+* say "help" to show a list of useful commands
 
 
 ## Training tasks

--- a/source/claudia/bad.html.md.erb
+++ b/source/claudia/bad.html.md.erb
@@ -6,6 +6,7 @@ title: Issues for Claudia
 <style>
 #content {
   max-width: 50em;
+  min-width:  960px;
 }
 </style>
 <% end %>

--- a/source/claudia/bad.html.md.erb
+++ b/source/claudia/bad.html.md.erb
@@ -20,7 +20,7 @@ title: Issues for Claudia
 ## Quiz questions
 
 <form action="<%= url_for '/fake.html' %>" method="get">
-  <%= partial "/_example_snippets/form_fields_no_label/bad", locals: { right_align_inputs: true } %>
+  <%= partial "/_example_snippets/form_fields_no_label/bad" %>
 
   <button class="govuk-button" data-module="govuk-button">
     Send

--- a/source/setup/chrome.html.md
+++ b/source/setup/chrome.html.md
@@ -15,7 +15,7 @@ Instead of using High Contrast mode, install the [High Contrast extension](https
 
 Instead of using the magnifier, zoom in via Settings > Appearance > Page zoom: select "400%" (once per device)
 
-Note: This will be a different experience than using the magnifier and the training tasks will not make sense with this setup
+Note: This will be a different experience than using the magnifier
 
 
 ## Ashleigh

--- a/source/simone/index.html.md
+++ b/source/simone/index.html.md
@@ -21,7 +21,7 @@ More about the [persona on GOV.UK](https://www.gov.uk/government/publications/un
 
 ## Chromebook help
 
-Selecting the text and pressing 'Search + S' will read out the text.
+Selecting the text and pressing 'Search + S' will read out the text. (When not on a Chromebook, just select the text.)
 
 You will have to stop the simulation for this to work properly: Select the Tampermonkey icon <img src="https://tampermonkey.freetls.fastly.net/images/icon.png" style="width: 16px; height: 16px;" alt="" /> next to the address bar and click "Enabled".
 

--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -13,7 +13,18 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
 @import "govuk/components/panel/panel";
 @import "govuk/components/radios/radios";
 
+/*
+  Heading anchors are confusing screen reader users doing Ashleigh's tasks.
+  This hides their icons from anything without a sidebar. It's a bit of a hack.
+  Pages with sidebars are more likely to be documentation and to benefit from the anchors.
+*/
+.app-pane__body:not([data-module="in-page-navigation"]) .anchored-heading__icon {
+  display: none;
+}
+
 /* ____________ example snippets ____________ */
+
+/* pagination */
 
 .pagination {
   padding-top: 1em;
@@ -24,6 +35,8 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
   border: 2px solid;
   margin-right: .5em;
 }
+
+/* large_blocks_of_text */
 
 .govuk-panel.bad {
   color: $govuk-border-colour;
@@ -36,6 +49,8 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
 .govuk-panel.good .govuk-panel__body {
   font-size: 24px;
 }
+
+/* table */
 
 .fullscreen-scrollable-table {
   overflow-x: auto;
@@ -74,6 +89,8 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
     white-space: nowrap;
   }
 }
+
+/* tooltip (used in table) */
 
 .tooltip-trigger {
   color: $govuk-link-colour;
@@ -123,6 +140,8 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
   box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
 }
 
+/* refer_to_colour */
+
 .govuk-button.red {
   background-color: $govuk-error-colour;
 }
@@ -135,6 +154,8 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
   display: inline-block;
 }
 
+/* icon_font */
+
 /* make icons from icon font bigger */
 .social-media > span {
   font-size: 200%;
@@ -144,6 +165,8 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
   display: inline-block;
   text-decoration: none;
 }
+
+/* form_field */
 
 div.govuk-label,
 div.govuk-fieldset__legend {
@@ -163,15 +186,6 @@ div.govuk-fieldset__legend + .govuk-radios {
 */
 .govuk-form-group:after {
   width: 0;
-}
-
-/*
-  Heading anchors are confusing screen reader users doing Ashleigh's tasks.
-  This hides their icons from anything without a sidebar. It's a bit of a hack.
-  Pages with sidebars are more likely to be documentation and to benefit from the anchors.
-*/
-.app-pane__body:not([data-module="in-page-navigation"]) .anchored-heading__icon {
-  display: none;
 }
 
 

--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -178,6 +178,10 @@ div.govuk-fieldset__legend + .govuk-radios {
   float: right;
 }
 
+div.govuk-label + input.govuk-\!-width-one-quarter {
+  width: 25% !important;
+}
+
 /*
   This fixes an odd behaviour with Claudia's bad example page:
   Although we intentionally removed the labels before the form fields,

--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -145,6 +145,16 @@ $govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", san
   text-decoration: none;
 }
 
+div.govuk-label,
+div.govuk-fieldset__legend {
+  float: left;
+}
+
+div.govuk-label + input,
+div.govuk-fieldset__legend + .govuk-radios {
+  float: right;
+}
+
 /*
   This fixes an odd behaviour with Claudia's bad example page:
   Although we intentionally removed the labels before the form fields,


### PR DESCRIPTION
Now that we're using the Chrome browser setup much more than the Chromebook setup due to working remotely, this PR:

* makes Claudia's training tasks also work when zooming in
* clarifies a few things within the help texts
* updates the number of ministers
* and makes some minor improvements to the CSS