### PR TITLE
Improve Pawel's task with buttons referring to colour

### DIFF
--- a/source/_example_snippets/refer_to_colour/_bad.erb
+++ b/source/_example_snippets/refer_to_colour/_bad.erb
@@ -1,13 +1,13 @@
-## Click the red button
+## Click the blue button
 
 <form action="<%= url_for '/fail.html' %>" method="get" class="game-button">
-  <button class="govuk-button" data-module="govuk-button">Click</button>
+  <button class="govuk-button" data-module="govuk-button">Submit</button>
 </form>
 
 <form action="<%= url_for '/success.html' %>" method="get" class="game-button">
-  <button class="govuk-button red" data-module="govuk-button">Click</button>
+  <button class="govuk-button blue" data-module="govuk-button">Save</button>
 </form>
 
 <form action="<%= url_for '/fail.html' %>" method="get" class="game-button">
-  <button class="govuk-button blue" data-module="govuk-button">Click</button>
+  <button class="govuk-button red" data-module="govuk-button">Cancel</button>
 </form>

--- a/source/_example_snippets/refer_to_colour/_good.erb
+++ b/source/_example_snippets/refer_to_colour/_good.erb
@@ -1,13 +1,13 @@
-## Click the Koala button
+## Click the Save button
 
 <form action="<%= url_for '/fail.html' %>" method="get" class="game-button">
-  <button class="govuk-button" data-module="govuk-button">Rabbit</button>
+  <button class="govuk-button" data-module="govuk-button">Submit</button>
 </form>
 
 <form action="<%= url_for '/success.html' %>" method="get" class="game-button">
-  <button class="govuk-button red" data-module="govuk-button">Koala</button>
+  <button class="govuk-button blue" data-module="govuk-button">Save</button>
 </form>
 
 <form action="<%= url_for '/fail.html' %>" method="get" class="game-button">
-  <button class="govuk-button blue" data-module="govuk-button">Wolf</button>
+  <button class="govuk-button red" data-module="govuk-button">Cancel</button>
 </form>


### PR DESCRIPTION
Pawel (who changes colours on websites) has a task to "Click the red button" on his page with issues which changes to "Click the Koala button" on his page with fixes.
This changes the example buttons to be the same and instead of "Click" or "Koala", they say "Submit", "Save" and "Cancel".
That is a more realistic scenario.

## Screenshots before

<img width="375" alt="" src="https://user-images.githubusercontent.com/108893/99994483-f7cf8b00-2db0-11eb-9160-34bd64821916.png">
<img width="411" alt="" src="https://user-images.githubusercontent.com/108893/99994476-f69e5e00-2db0-11eb-83b6-837745e270e1.png">

## Screenshots after

<img width="386" alt="" src="https://user-images.githubusercontent.com/108893/99994540-0ae25b00-2db1-11eb-9ce9-fa45655e5c79.png">
<img width="396" alt="" src="https://user-images.githubusercontent.com/108893/99994536-0a49c480-2db1-11eb-9a85-bbe5c7155973.png">
