### PR TITLE
Update accessibility statement dates

### DIFF
--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -81,7 +81,7 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the accessibility issues with the Technical Documentation Template by the end of 2020.
+We plan to fix the accessibility issues with the Technical Documentation Template by the end of March 2021.
 
 ## Preparation of this accessibility statement
 


### PR DESCRIPTION
Updated the date for fixing the Tech Docs Template accessibility issues from “end of December 2020” to “end of March 2021”. As a result of resourcing pressures and re-prioritisation this year, it’s taking longer than we hoped to arrange developer and designer resources to fix the accessibility issues.