### PR TITLE
Make Chris colourblind

### DIFF
--- a/source/_example_snippets/refer_to_colour/_bad.erb
+++ b/source/_example_snippets/refer_to_colour/_bad.erb
@@ -1,10 +1,13 @@
-## Click the blue button
+<% action1 = colour == 'blue' ? 'fail' : 'success' %>
+<% action2 = colour == 'green' ? 'fail' : 'success' %>
 
-<form action="<%= url_for '/fail.html' %>" method="get" class="game-button">
+## Click the <%= colour %> button
+
+<form action="<%= url_for "/#{action1}.html" %>" method="get" class="game-button">
   <button class="govuk-button" data-module="govuk-button">Submit</button>
 </form>
 
-<form action="<%= url_for '/success.html' %>" method="get" class="game-button">
+<form action="<%= url_for "/#{action2}.html" %>" method="get" class="game-button">
   <button class="govuk-button blue" data-module="govuk-button">Save</button>
 </form>
 

--- a/source/_example_snippets/refer_to_colour/_good.erb
+++ b/source/_example_snippets/refer_to_colour/_good.erb
@@ -1,10 +1,13 @@
-## Click the Save button
+<% action1 = colour == 'blue' ? 'fail' : 'success' %>
+<% action2 = colour == 'green' ? 'fail' : 'success' %>
 
-<form action="<%= url_for '/fail.html' %>" method="get" class="game-button">
+## Click the <%= name %> button
+
+<form action="<%= url_for "/#{action1}.html" %>" method="get" class="game-button">
   <button class="govuk-button" data-module="govuk-button">Submit</button>
 </form>
 
-<form action="<%= url_for '/success.html' %>" method="get" class="game-button">
+<form action="<%= url_for "/#{action2}.html" %>" method="get" class="game-button">
   <button class="govuk-button blue" data-module="govuk-button">Save</button>
 </form>
 

--- a/source/chris/bad.html.md.erb
+++ b/source/chris/bad.html.md.erb
@@ -15,3 +15,5 @@ title: Issues for Chris
 # <%= current_page.data.title %>
 
 <%= partial "/_example_snippets/table/bad" %>
+
+<%= partial "/_example_snippets/refer_to_colour/bad" %>

--- a/source/chris/bad.html.md.erb
+++ b/source/chris/bad.html.md.erb
@@ -16,4 +16,4 @@ title: Issues for Chris
 
 <%= partial "/_example_snippets/table/bad" %>
 
-<%= partial "/_example_snippets/refer_to_colour/bad" %>
+<%= partial "/_example_snippets/refer_to_colour/bad", locals: { colour: "green" } %>

--- a/source/chris/good.html.md.erb
+++ b/source/chris/good.html.md.erb
@@ -15,3 +15,5 @@ title: Fixes for Chris
 # <%= current_page.data.title %>
 
 <%= partial "/_example_snippets/table/good" %>
+
+<%= partial "/_example_snippets/refer_to_colour/good" %>

--- a/source/chris/good.html.md.erb
+++ b/source/chris/good.html.md.erb
@@ -16,4 +16,4 @@ title: Fixes for Chris
 
 <%= partial "/_example_snippets/table/good" %>
 
-<%= partial "/_example_snippets/refer_to_colour/good" %>
+<%= partial "/_example_snippets/refer_to_colour/good", locals: { colour: "green", name: "Submit" } %>

--- a/source/chris/index.html.md
+++ b/source/chris/index.html.md
@@ -54,7 +54,7 @@ There are 2 versions of an example page. Version 1 shows the issues Chris experi
 Do the following tasks logged in as Chris:
 
 1. There is a table. Its country column includes an explanation indicated by a question mark. Try to select that question mark to find out what the explanation is.
-2. The end date column might be hidden. Try to find out what the end date of the Algeria entry is.
+2. There are a couple of buttons below the table. Try to select the correct button.
 
 [Version 1 - issues for Chris](bad.html)
 

--- a/source/chris/index.html.md
+++ b/source/chris/index.html.md
@@ -12,7 +12,7 @@ parent: /index.html
 
 * 53 year old management accountant
 
-* rheumatoid arthritis
+* rheumatoid arthritis and colour vision deficiency (colour blindness)
 
 * uses keyboard only, no mouse and just started using voice control
 

--- a/source/pawel/bad.html.md.erb
+++ b/source/pawel/bad.html.md.erb
@@ -18,4 +18,4 @@ title: Issues for Pawel
 
 <%= partial "/_example_snippets/complex_language/bad" %>
 
-<%= partial "/_example_snippets/refer_to_colour/bad" %>
+<%= partial "/_example_snippets/refer_to_colour/bad", locals: { colour: "blue" } %>

--- a/source/pawel/good.html.md.erb
+++ b/source/pawel/good.html.md.erb
@@ -18,4 +18,4 @@ title: Issues for Pawel
 
 <%= partial "/_example_snippets/complex_language/good" %>
 
-<%= partial "/_example_snippets/refer_to_colour/good" %>
+<%= partial "/_example_snippets/refer_to_colour/good", locals: { colour: "blue", name: "Save" } %>

--- a/source/raw_assets/monochrome.user.css
+++ b/source/raw_assets/monochrome.user.css
@@ -1,0 +1,13 @@
+/* ==UserStyle==
+@name         Monochrome
+@namespace    https://github.com/alphagov/accessibility-personas
+@version      1.0.0
+@license      MIT
+@author       Crown Copyright (Government Digital Service)
+@description  Remove colours and make everything monochrome to simulate some form of colour vision deficiency
+@homepageURL  https://alphagov.github.io/accessibility-personas/
+==/UserStyle== */
+
+* {
+  filter: grayscale(1) !important;
+}

--- a/source/setup/chromebook.html.md
+++ b/source/setup/chromebook.html.md
@@ -134,9 +134,10 @@ To set up the simulation for Chris' condition:
 * install the extension [Stylus](https://chrome.google.com/webstore/detail/stylus/clngdbkpkpeebahjckkjfobafhncgmne)
 * open its options, select a cloud provider under "Sync to cloud" and connect to it (once per device)
 * open [remove-cursor.user.css](raw_assets/remove-cursor.user.css) in the browser
+* open [monochrome.user.css](raw_assets/monochrome.user.css) in the browser
 * when Stylus opens, select the "Install style" button
 
-This will cause the mouse pointer to disappear in the browser.
+This will cause the mouse pointer to disappear in the browser and colours to turn grey.
 
 ### Use Chris' assistive technology
 

--- a/source/setup/index.html.md
+++ b/source/setup/index.html.md
@@ -25,7 +25,7 @@ You can also set up [personas in Chrome browsers](chrome.html) on any operating 
 | Claudia  | Magnifier, high contrast, etc    | (none)                                    |
 | Ashleigh | Screen reader                    | Blurred vision                            |
 | Ron      | (none)                           | Mildly blurred vision, wobbly pointer     |
-| Chris    | Voice control                    | Disabled mouse or trackpad                |
+| Chris    | Voice control                    | Disabled mouse or trackpad, grey colours  |
 | Pawel    | Soothing colours                 | Distracting sounds, images and animations |
 | Simone   | Tinted background, Dyslexia font | Scrambled letters                         |
 | Saleem   | (none)                           | Translated to Pig Latin                   |


### PR DESCRIPTION
People often ask for a colourblind persona and Chris makes the most sense for that.

This was implemented changing all colours to greyscale. Even though monochromacy is the rarest form of colour blindness, it is the easiest to implement.

I've also changed one of the two tasks for Chris to include an issue with colours (the same as for Pawel). I could have removed the table on Chris' training task pages and extracted the tooltip to remove all references to the previous task. But I couldn't think of enough content to add instead.