### PR TITLE
Fix Ron's cursor

### DIFF
--- a/source/raw_assets/wobbly-mouse.user.js
+++ b/source/raw_assets/wobbly-mouse.user.js
@@ -7,7 +7,7 @@
 // @description  Wobble the cursor to simulate having issues using a mouse
 // @homepageURL  https://alphagov.github.io/accessibility-personas/
 // @include      *
-// @grant        none
+// @grant        GM_addStyle
 // @nocompat     Chrome
 // ==/UserScript==
 
@@ -35,6 +35,10 @@ function setStyle(element, style) {
     element.style[s] = style[s];
   }
 }
+
+GM_addStyle('* {cursor: none !important;}');
+GM_addStyle('#wds-parkinsonsCursor {background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAVCAMAAABBhy+7AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAA+VBMVEUAAAAAAAD7+/sAAAD09PQAAAAAAAD09PTz8/PS0tJqampubm5+fn6np6cAAAD19fXw8PD39/cJCQkAAAAAAAAAAAAAAAD19fWzs7OgoKDX19cAAAD+/v6ysrIAAAAICAj29vb09PQAAAAAAADFxcUAAAAAAADR0dH8/Py2trYAAAAAAAAAAABRUVH29vb39/fJycni4uLp6emjo6MHBwcAAAAAAAAAAAD////T09MUFBTS0tIAAAAXFxfb29sbGxseHh4aGhrr6+vv7+/39/c5OTni4uIKCgqurq5BQUFmZmZDQ0PQ0NDW1tY9PT1tbW2np6cgICCioqIFyGmYAAAAOHRSTlMAAooIjg4QiH6dTUpBMQT92N4bFBILA/t4aU0B+3AgIt6zBQ1lGwqE/CMGCQcp9txCpsJpJQ8iGe73bXgAAAABYktHRACIBR1IAAAACXBIWXMAAAsSAAALEgHS3X78AAAArUlEQVQY003P1xKCMBRFUaKCvSuWWFFsYG9Rr1jA3v3/jzGMwOS8rac9h0MuxDFzEw9rnixYC2S5YiwQYE0Ja82xSdhoXsSQ2ocYOrZo26Zlk1vY7XXdINSUh+MJzv5AMBSOUF6isSvc4olkKi1SZrK5O8AjLyKEOaFQLJUrT3hVJTNUq8sNofmGT6uNKTu8gtVu72v0B2YXi5hDqeFoPJk6txR5NuclbBOpyh8/ou0enbQh1QcAAAAASUVORK5CYII=");');
+GM_addStyle('#wds-parkinsonsCursor {position: absolute !important;z-index: 9999999 !important;width: 21px;height: 21px;pointer-events: none;background-repeat: no-repeat;transition: left 0.05s, top 0.05s;}');
 
 function mousemoveHandler(e) {
   // Save the position of the fake cursor
@@ -76,23 +80,9 @@ function setOffset() {
   offsetY = random(-shakeSpeed, shakeSpeed);
 }
 
-function addStyles(css) {
-    var head, style;
-    head = document.getElementsByTagName('head')[0];
-    if (!head) { return; }
-    style = document.createElement('style');
-    style.type = 'text/css';
-    style.innerHTML = css;
-    head.appendChild(style);
-}
-
 (function() {
 
   'use strict';
-
-  addStyles('body * {cursor: none !important;}');
-  addStyles('#wds-parkinsonsCursor {background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAVCAMAAABBhy+7AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAA+VBMVEUAAAAAAAD7+/sAAAD09PQAAAAAAAD09PTz8/PS0tJqampubm5+fn6np6cAAAD19fXw8PD39/cJCQkAAAAAAAAAAAAAAAD19fWzs7OgoKDX19cAAAD+/v6ysrIAAAAICAj29vb09PQAAAAAAADFxcUAAAAAAADR0dH8/Py2trYAAAAAAAAAAABRUVH29vb39/fJycni4uLp6emjo6MHBwcAAAAAAAAAAAD////T09MUFBTS0tIAAAAXFxfb29sbGxseHh4aGhrr6+vv7+/39/c5OTni4uIKCgqurq5BQUFmZmZDQ0PQ0NDW1tY9PT1tbW2np6cgICCioqIFyGmYAAAAOHRSTlMAAooIjg4QiH6dTUpBMQT92N4bFBILA/t4aU0B+3AgIt6zBQ1lGwqE/CMGCQcp9txCpsJpJQ8iGe73bXgAAAABYktHRACIBR1IAAAACXBIWXMAAAsSAAALEgHS3X78AAAArUlEQVQY003P1xKCMBRFUaKCvSuWWFFsYG9Rr1jA3v3/jzGMwOS8rac9h0MuxDFzEw9rnixYC2S5YiwQYE0Ja82xSdhoXsSQ2ocYOrZo26Zlk1vY7XXdINSUh+MJzv5AMBSOUF6isSvc4olkKi1SZrK5O8AjLyKEOaFQLJUrT3hVJTNUq8sNofmGT6uNKTu8gtVu72v0B2YXi5hDqeFoPJk6txR5NuclbBOpyh8/ou0enbQh1QcAAAAASUVORK5CYII=");');
-  addStyles('#wds-parkinsonsCursor {position: absolute !important;z-index: 9999999 !important;width: 21px;height: 21px;pointer-events: none;background-repeat: no-repeat;transition: left 0.05s, top 0.05s;}');
 
   let cursorType = appVersion.includes('Mac') ? 'mac' : 'windows';
 

--- a/source/raw_assets/wobbly-mouse.user.js
+++ b/source/raw_assets/wobbly-mouse.user.js
@@ -26,6 +26,56 @@ let cursor = null,
   css = null,
   clickedElement = null;
 
+const css = `
+* {
+  cursor: none !important;
+}
+#wds-parkinsonsCursor {
+  position: absolute !important;
+  z-index: 9999999 !important;
+  width: 21px;
+  height: 21px;
+  pointer-events: none;
+  transition: left 0.05s, top 0.05s;
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+  transform: rotate(-68deg) skew(-30deg, -30deg);
+}
+#wds-parkinsonsCursor::before,
+#wds-parkinsonsCursor::after {
+  display: block;
+  content: "";
+  position: absolute;
+  top: -10px;
+  left: -10px;
+  box-sizing: border-box;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+}
+#wds-parkinsonsCursor::before {
+  color: #333;
+  border-width: 10px;
+}
+#wds-parkinsonsCursor::after {
+  top: -8px;
+  left: -6px;
+  color: #fff;
+  border-width: 7px;
+}
+#wds-parkinsonsCursor.mac::before {
+  color: #fff;
+}
+#wds-parkinsonsCursor.mac::after {
+  color: #333;
+}
+`
+
+GM_addStyle(css);
+
 function random(min, max) {
   return Math.floor(min + Math.random() * (max - min + 1));
 }
@@ -35,12 +85,6 @@ function setStyle(element, style) {
     element.style[s] = style[s];
   }
 }
-
-GM_addStyle('* {cursor: none !important;}');
-GM_addStyle('#wds-parkinsonsCursor { position: absolute !important; z-index: 9999999 !important; width: 21px; height: 21px; pointer-events: none; transition: left 0.05s, top 0.05s; box-sizing: border-box; padding: 0; margin: 0; transform: rotate(-68deg) skew(-30deg, -30deg); }');
-GM_addStyle('#wds-parkinsonsCursor::before, #wds-parkinsonsCursor::after { display: block; content: ""; position: absolute; top: -10px; left: -10px; box-sizing: border-box; width: 0; height: 0; border-style: solid; border-bottom-color: transparent; border-left-color: transparent; }');
-GM_addStyle('#wds-parkinsonsCursor::before { color: #333; border-width: 10px; } #wds-parkinsonsCursor::after { top: -8px; left: -6px; color: #fff; border-width: 7px; }');
-GM_addStyle('#wds-parkinsonsCursor.mac::before { color: #fff; } #wds-parkinsonsCursor.mac::after { color: #333; }');
 
 function mousemoveHandler(e) {
   // Save the position of the fake cursor

--- a/source/raw_assets/wobbly-mouse.user.js
+++ b/source/raw_assets/wobbly-mouse.user.js
@@ -40,6 +40,7 @@ GM_addStyle('body * {cursor: none !important;}');
 GM_addStyle('#wds-parkinsonsCursor { position: absolute !important; z-index: 9999999 !important; width: 21px; height: 21px; pointer-events: none; transition: left 0.05s, top 0.05s; box-sizing: border-box; padding: 0; margin: 0; transform: rotate(-68deg) skew(-30deg, -30deg); }');
 GM_addStyle('#wds-parkinsonsCursor::before, #wds-parkinsonsCursor::after { display: block; content: ""; position: absolute; top: -10px; left: -10px; box-sizing: border-box; width: 0; height: 0; border-style: solid; border-bottom-color: transparent; border-left-color: transparent; }');
 GM_addStyle('#wds-parkinsonsCursor::before { color: #333; border-width: 10px; } #wds-parkinsonsCursor::after { top: -8px; left: -6px; color: #fff; border-width: 7px; }');
+GM_addStyle('#wds-parkinsonsCursor.mac::before { color: #fff; } #wds-parkinsonsCursor.mac::after { color: #333; }');
 
 function mousemoveHandler(e) {
   // Save the position of the fake cursor

--- a/source/raw_assets/wobbly-mouse.user.js
+++ b/source/raw_assets/wobbly-mouse.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Wobbly mouse
 // @namespace    https://github.com/alphagov/accessibility-personas
-// @version      1.0.0
+// @version      1.0.1
 // @license      ISC
 // @author       Metamatrix AB [https://github.com/Metamatrix/web-disability-simulator] and Crown Copyright (Government Digital Service)
 // @description  Wobble the cursor to simulate having issues using a mouse
@@ -36,9 +36,10 @@ function setStyle(element, style) {
   }
 }
 
-GM_addStyle('* {cursor: none !important;}');
-GM_addStyle('#wds-parkinsonsCursor {background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAVCAMAAABBhy+7AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAA+VBMVEUAAAAAAAD7+/sAAAD09PQAAAAAAAD09PTz8/PS0tJqampubm5+fn6np6cAAAD19fXw8PD39/cJCQkAAAAAAAAAAAAAAAD19fWzs7OgoKDX19cAAAD+/v6ysrIAAAAICAj29vb09PQAAAAAAADFxcUAAAAAAADR0dH8/Py2trYAAAAAAAAAAABRUVH29vb39/fJycni4uLp6emjo6MHBwcAAAAAAAAAAAD////T09MUFBTS0tIAAAAXFxfb29sbGxseHh4aGhrr6+vv7+/39/c5OTni4uIKCgqurq5BQUFmZmZDQ0PQ0NDW1tY9PT1tbW2np6cgICCioqIFyGmYAAAAOHRSTlMAAooIjg4QiH6dTUpBMQT92N4bFBILA/t4aU0B+3AgIt6zBQ1lGwqE/CMGCQcp9txCpsJpJQ8iGe73bXgAAAABYktHRACIBR1IAAAACXBIWXMAAAsSAAALEgHS3X78AAAArUlEQVQY003P1xKCMBRFUaKCvSuWWFFsYG9Rr1jA3v3/jzGMwOS8rac9h0MuxDFzEw9rnixYC2S5YiwQYE0Ja82xSdhoXsSQ2ocYOrZo26Zlk1vY7XXdINSUh+MJzv5AMBSOUF6isSvc4olkKi1SZrK5O8AjLyKEOaFQLJUrT3hVJTNUq8sNofmGT6uNKTu8gtVu72v0B2YXi5hDqeFoPJk6txR5NuclbBOpyh8/ou0enbQh1QcAAAAASUVORK5CYII=");');
-GM_addStyle('#wds-parkinsonsCursor {position: absolute !important;z-index: 9999999 !important;width: 21px;height: 21px;pointer-events: none;background-repeat: no-repeat;transition: left 0.05s, top 0.05s;}');
+GM_addStyle('body * {cursor: none !important;}');
+GM_addStyle('#wds-parkinsonsCursor { position: absolute !important; z-index: 9999999 !important; width: 21px; height: 21px; pointer-events: none; transition: left 0.05s, top 0.05s; box-sizing: border-box; padding: 0; margin: 0; transform: rotate(-68deg) skew(-30deg, -30deg); }');
+GM_addStyle('#wds-parkinsonsCursor::before, #wds-parkinsonsCursor::after { display: block; content: ""; position: absolute; top: -10px; left: -10px; box-sizing: border-box; width: 0; height: 0; border-style: solid; border-bottom-color: transparent; border-left-color: transparent; }');
+GM_addStyle('#wds-parkinsonsCursor::before { color: #333; border-width: 10px; } #wds-parkinsonsCursor::after { top: -8px; left: -6px; color: #fff; border-width: 7px; }');
 
 function mousemoveHandler(e) {
   // Save the position of the fake cursor

--- a/source/raw_assets/wobbly-mouse.user.js
+++ b/source/raw_assets/wobbly-mouse.user.js
@@ -36,7 +36,7 @@ function setStyle(element, style) {
   }
 }
 
-GM_addStyle('body * {cursor: none !important;}');
+GM_addStyle('* {cursor: none !important;}');
 GM_addStyle('#wds-parkinsonsCursor { position: absolute !important; z-index: 9999999 !important; width: 21px; height: 21px; pointer-events: none; transition: left 0.05s, top 0.05s; box-sizing: border-box; padding: 0; margin: 0; transform: rotate(-68deg) skew(-30deg, -30deg); }');
 GM_addStyle('#wds-parkinsonsCursor::before, #wds-parkinsonsCursor::after { display: block; content: ""; position: absolute; top: -10px; left: -10px; box-sizing: border-box; width: 0; height: 0; border-style: solid; border-bottom-color: transparent; border-left-color: transparent; }');
 GM_addStyle('#wds-parkinsonsCursor::before { color: #333; border-width: 10px; } #wds-parkinsonsCursor::after { top: -8px; left: -6px; color: #fff; border-width: 7px; }');

--- a/source/ron/index.html.md
+++ b/source/ron/index.html.md
@@ -23,6 +23,8 @@ More about the [persona on GOV.UK](https://www.gov.uk/government/publications/un
 
 As Ron is not very technical, do not use anything which might help. For example, do not zoom into the page and do not use the keyboard to navigate.
 
+Because of that you might encounter issues which are not fixable. This is good for demonstrating that users have a worse experience when they don't know that there is assistive technology that would help them.
+
 
 ## Training tasks
 


### PR DESCRIPTION
When websites use a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) (like www.gov.uk does) the cursor doesn't appear because it is an image that cannot be loaded.

This changes that to use a CSS cursor instead. The CSS is not using an arrow but a rudimentary triangle which looks somewhat similar to the default arrow on operating systems but not identical.

<img width="327" alt="CSS pointer as a black triangle with a white border" src="https://github.com/user-attachments/assets/0a2ece56-dd71-4f69-857f-ae9389da2e0a" />

While I was at it I also switched from using the script's own `addStyles()` function to the [`GM_addStyle()`](https://www.tampermonkey.net/documentation.php#api:GM_addStyle) function that is provided by TamperMonkey.

And because there were unfinished efforts in the code to switch to a different cursor depending on operating system, I've added that as well. By default it's a white triangle with a black border. And on a Mac it's a black triangle with a white border.

During testing I also found an issue of the default cursor showing and fixed that as well.

Although it's technically not related to this work, I've also added an explanation that Ron's issues cannot necessarily be fixed. That would close #89.