### PR TITLE
Fix some broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ These pages include:
 
 ## Running the tool
 
-The tool is based on the [tech docs template](https://tdt-documentation.london.cloudapps.digital/).
-Read more in depth documentation on there.
+The tool is based on the [Tech Docs Template](https://github.com/alphagov/tech-docs-template).
+Read more about it on [its old documentation](https://github.com/alphagov/tdt-documentation).
 
 But in short...
 

--- a/source/accessibility.html.md
+++ b/source/accessibility.html.md
@@ -58,7 +58,7 @@ The content listed below is non-accessible for the following reasons.
 
 #### Non-compliance with the accessibility regulations
 
-Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
+Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://github.com/alphagov/tdt-documentation/blob/main/source/accessibility/index.html.md.erb).
 
 Some pages have intentional accessibility issues to demonstrate those issues.
 


### PR DESCRIPTION
Fix links that went to the old documentation for the Tech Docs Template.
Tech Docs have been discontinued and its documentation was taken down.
But the repo is still there, so I changed the links to go to the repo instead.