### PR TITLE
Single userscript for Ashleigh

### DIFF
--- a/source/raw_assets/Persona-Ashleigh.user.js
+++ b/source/raw_assets/Persona-Ashleigh.user.js
@@ -12,7 +12,7 @@
 // ==/UserScript==
 
 /**
- * Blur the screen heavily
+ * Blur the screen heavily and display a hint to use your own screen reader
  * @author Crown Copyright (Government Digital Service)
  * @license MIT
  */
@@ -20,6 +20,18 @@
 let css = `
   body {
     filter: blur(7px) contrast(70%);
+  }
+
+  html::before {
+    content: "To use this persona, you have to use your own system's screen reader!";
+    display: block;
+    padding: 2px 0 4px;
+    background-color: #eee;
+    color: #333;
+    font-family: sans-serif;
+    font-size: 16px;
+    font-weight: bold;
+    text-align: center;
   }
 }
 `

--- a/source/raw_assets/Persona-Ashleigh.user.js
+++ b/source/raw_assets/Persona-Ashleigh.user.js
@@ -1,0 +1,27 @@
+// ==UserScript==
+// @name         Persona Ashleigh
+// @namespace    https://github.com/alphagov/accessibility-personas
+// @version      1.0.0
+// @license      MIT
+// @author       Crown Copyright (Government Digital Service)
+// @description  Ashleigh, a severely sight impaired screenreader user - the screen is heavily blurred to simulate some form of blindness, must use a screen reader in addition to the script
+// @homepageURL  https://alphagov.github.io/accessibility-personas/
+// @include      *
+// @grant        GM_addStyle
+// @nocompat     Chrome
+// ==/UserScript==
+
+/**
+ * Blur the screen heavily
+ * @author Crown Copyright (Government Digital Service)
+ * @license MIT
+ */
+
+let css = `
+  body {
+    filter: blur(7px) contrast(70%);
+  }
+}
+`
+
+GM_addStyle(css);

--- a/source/raw_assets/Persona-Ashleigh.user.js
+++ b/source/raw_assets/Persona-Ashleigh.user.js
@@ -17,7 +17,7 @@
  * @license MIT
  */
 
-let css = `
+const css = `
   body {
     filter: blur(7px) contrast(70%);
   }


### PR DESCRIPTION
This is part of a bigger change which changes the whole way the personas are installed.
While previously you'd have to have 7 different Google accounts and multiple browser extensions (and/or Chromebooks), now you only need 1 single extension (Tampermonkey) and 1 single userscript per persona. That is much easier to install. And it can be used across multiple browsers and operating systems.

For Ashleigh this means:

* Moved content from the userstyle to a new userscript
* Added a hint to use your own screen reader to the userscript, as we can neither have a screen reader in userscript, nor use the ChromeVox extension as it's no longer available

That also means that there are no changes in functionality to the previous solution, other than not including a screen reader.

I have intentionally not removed the previous styles because users might still rely on them being there.
