### PR TITLE
Single userscript for Saleem

### DIFF
--- a/source/raw_assets/Persona-Saleem.user.js
+++ b/source/raw_assets/Persona-Saleem.user.js
@@ -17,7 +17,7 @@
  * @license MIT
  */
 
-let css = `
+const css = `
   html::before {
     content: "Remember to turn off your sound";
     display: block;
@@ -42,17 +42,18 @@ GM_addStyle(css);
  * @license MIT
  */
 
-(function() {
+
+(function () {
   'use strict';
 
   function translateWord(str) {
-    var wordArray = str.split('');
-    var vowels = 'AaEeIiOoUu';
-    var consonant;
+    const wordArray = str.split('');
+    const vowels = 'AaEeIiOoUu';
+    let consonant;
 
-    for (var i = 0; i < wordArray.length; i++) {
-      var wordStartsWithVowel = vowels.includes(wordArray[0]);
-      var wordStartsWithVowelOrY = wordStartsWithVowel || 'Yy'.includes(wordArray[0]);
+    for (let i = 0; i < wordArray.length; i++) {
+      const wordStartsWithVowel = vowels.includes(wordArray[0]);
+      const wordStartsWithVowelOrY = wordStartsWithVowel || 'Yy'.includes(wordArray[0]);
 
       if (wordStartsWithVowel) {
         str = wordArray.join('');
@@ -75,16 +76,16 @@ GM_addStyle(css);
   }
 
   function translatePhrase(str) {
-    var originalString = str;
-    var originalArray = originalString.split(' ');
-    var translatedArray = originalArray.map(function(word) {
+    const originalString = str;
+    const originalArray = originalString.split(' ');
+    const translatedArray = originalArray.map(function (word) {
       word = translateWord(word);
 
-      for (var i = 0; i < word.length; i++) {
+      for (let i = 0; i < word.length; i++) {
         if (!word[i].match(/[a-z]/i) && (i < word.length)) {
-          var punctuation = word[i];
-          var punctuatedWordArray = word.split('');
-          var removedPunctuation = punctuatedWordArray.splice(i, 1);
+          const punctuation = word[i];
+          const punctuatedWordArray = word.split('');
+          punctuatedWordArray.splice(i, 1);
           if (i === 0) {
             word = punctuation + punctuatedWordArray.join('');
           } else if (i !== 0) {
@@ -94,8 +95,8 @@ GM_addStyle(css);
 
         if (word.charCodeAt(i) >= 65 && word.charCodeAt(i) <= 90) {
           word = word.toLowerCase();
-          var firstLetter = word.slice(0, 1);
-          var capLetter = firstLetter.toUpperCase();
+          const firstLetter = word.slice(0, 1);
+          const capLetter = firstLetter.toUpperCase();
           word = word.replace(firstLetter, capLetter);
         }
       }
@@ -105,7 +106,7 @@ GM_addStyle(css);
   }
 
   function translatePage() {
-    var walker = document.createTreeWalker(
+    const walker = document.createTreeWalker(
       document.body,
       NodeFilter.SHOW_TEXT,
       null,
@@ -113,7 +114,7 @@ GM_addStyle(css);
     );
 
     while (walker.nextNode()) {
-      var elem = walker.currentNode.parentElement.nodeName;
+      const elem = walker.currentNode.parentElement.nodeName;
       if (walker.currentNode.nodeValue.trim() && elem !== 'SCRIPT' && elem !== 'STYLE') {
         walker.currentNode.nodeValue = translatePhrase(walker.currentNode.nodeValue);
       }

--- a/source/raw_assets/Persona-Saleem.user.js
+++ b/source/raw_assets/Persona-Saleem.user.js
@@ -7,9 +7,33 @@
 // @description  Saleem, a profoundly deaf user - everything on the page is translated into Pig Latin to simulate English as a second language
 // @homepageURL  https://alphagov.github.io/accessibility-personas/
 // @include      *
-// @grant        none
+// @grant        GM_addStyle
 // @nocompat     Chrome
 // ==/UserScript==
+
+/**
+ * Display a reminder 
+ * @author Crown Copyright (Government Digital Service)
+ * @license MIT
+ */
+
+let css = `
+  html::before {
+    content: "Remember to turn off your sound";
+    display: block;
+    padding: 2px 0 4px;
+    background-color: #eee;
+    color: #333;
+    font-family: sans-serif;
+    font-size: 16px;
+    font-weight: bold;
+    text-align: center;
+  }
+}
+`
+
+GM_addStyle(css);
+
 
 /**
  * Translate to Pig Latin

--- a/source/raw_assets/Persona-Saleem.user.js
+++ b/source/raw_assets/Persona-Saleem.user.js
@@ -1,0 +1,101 @@
+// ==UserScript==
+// @name         Persona Saleem
+// @namespace    https://github.com/alphagov/accessibility-personas
+// @version      1.0.0
+// @license      MIT
+// @author       Chazona Baum and Crown Copyright (Government Digital Service)
+// @description  Saleem, a profoundly deaf user - everything on the page is translated into Pig Latin to simulate English as a second language
+// @homepageURL  https://alphagov.github.io/accessibility-personas/
+// @include      *
+// @grant        none
+// @nocompat     Chrome
+// ==/UserScript==
+
+/**
+ * Translate to Pig Latin
+ * @author Chazona Baum [https://codepen.io/chznbaum/pen/GNNwJZ]
+ * @author Crown Copyright (Government Digital Service)
+ * @license MIT
+ */
+
+(function() {
+  'use strict';
+
+  function translateWord(str) {
+    var wordArray = str.split('');
+    var vowels = 'AaEeIiOoUu';
+    var consonant;
+
+    for (var i = 0; i < wordArray.length; i++) {
+      var wordStartsWithVowel = vowels.includes(wordArray[0]);
+      var wordStartsWithVowelOrY = wordStartsWithVowel || 'Yy'.includes(wordArray[0]);
+
+      if (wordStartsWithVowel) {
+        str = wordArray.join('');
+        if (i === 0) {
+          str = str + 'way';
+        } else {
+          str = str + 'ay';
+        }
+        return str;
+      } else if (i !== 0 && wordStartsWithVowelOrY) {
+        str = wordArray.join('');
+        str = str + 'ay';
+        return str;
+      } else {
+        consonant = wordArray.shift();
+        wordArray.push(consonant);
+      }
+    }
+    return str;
+  }
+
+  function translatePhrase(str) {
+    var originalString = str;
+    var originalArray = originalString.split(' ');
+    var translatedArray = originalArray.map(function(word) {
+      word = translateWord(word);
+
+      for (var i = 0; i < word.length; i++) {
+        if (!word[i].match(/[a-z]/i) && (i < word.length)) {
+          var punctuation = word[i];
+          var punctuatedWordArray = word.split('');
+          var removedPunctuation = punctuatedWordArray.splice(i, 1);
+          if (i === 0) {
+            word = punctuation + punctuatedWordArray.join('');
+          } else if (i !== 0) {
+            word = punctuatedWordArray.join('') + punctuation;
+          }
+        }
+
+        if (word.charCodeAt(i) >= 65 && word.charCodeAt(i) <= 90) {
+          word = word.toLowerCase();
+          var firstLetter = word.slice(0, 1);
+          var capLetter = firstLetter.toUpperCase();
+          word = word.replace(firstLetter, capLetter);
+        }
+      }
+      return word;
+    });
+    return translatedArray.join(' ');
+  }
+
+  function translatePage() {
+    var walker = document.createTreeWalker(
+      document.body,
+      NodeFilter.SHOW_TEXT,
+      null,
+      false
+    );
+
+    while (walker.nextNode()) {
+      var elem = walker.currentNode.parentElement.nodeName;
+      if (walker.currentNode.nodeValue.trim() && elem !== 'SCRIPT' && elem !== 'STYLE') {
+        walker.currentNode.nodeValue = translatePhrase(walker.currentNode.nodeValue);
+      }
+    }
+  }
+
+  translatePage();
+
+})();


### PR DESCRIPTION
This is part of a bigger change which changes the whole way the personas are installed.
While previously you'd have to have 7 different Google accounts and multiple browser extensions (and/or Chromebooks), now you only need 1 single extension (Tampermonkey) and 1 single userscript per persona. That is much easier to install. And it can be used across multiple browsers and operating systems.

For Saleem this means:

* Moved content from the previous userscript (translate to Pig Latin) to a new userscript
* Added a hint to turn the sound off to the userscript, as turning the sound off programmatically is difficult (lots of videos are in iframes which you cannot access due to security reasons, and turning the tab mute cannot be done unless in a Chrome extension, and the previously used extension is dead)

That also means that there are no changes in functionality to the previous solution, other than turning the sound off not being done automatically.

I have intentionally not removed the previous script because users might still rely on it being there.
