### PR TITLE
Fix Chris's script making CSS-generated content wonky

### DIFF
--- a/source/raw_assets/Persona-Chris.user.js
+++ b/source/raw_assets/Persona-Chris.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Persona Chris
 // @namespace    https://github.com/alphagov/accessibility-personas
-// @version      1.0.0
+// @version      1.0.1
 // @license      MIT
 // @author       Crown Copyright (Government Digital Service)
 // @description  Chris, a user with rheumatoid arthritis - the pointer is removed to make it harder to use the mouse or touchpad, colours are removed to simulate some form of colour vision deficiency, could also be used with a voice control tool
@@ -26,4 +26,4 @@ GM_addStyle('* { cursor: none !important; pointer-events: none !important; }');
  * @license MIT
  */
 
-GM_addStyle('* { filter: grayscale(1) !important; }');
+GM_addStyle('html { filter: grayscale(1) !important; }');

--- a/source/setup/alternatives.html.md
+++ b/source/setup/alternatives.html.md
@@ -6,7 +6,7 @@ layout: layout
 # Alternative persona setups
 
 Our personas have inspired other people to create their own version.
-Here are some of the those other versions.
+Here are some of those other versions.
 
 
 ## [HMRC's Virtual Empathy Hub](https://personas-prototype.herokuapp.com/)


### PR DESCRIPTION
When using Chris's script, specifically the part that makes everything greyscale, CSS-generated content is moved.
I don't understand why that happens. But applying the style to just `html` rather than everything (`*`) fixes it. And it's not needed on everything.

Here are some examples of how it behaved before the fix:
<img width="329" alt="The circles for radio buttons moved below the label." src="https://github.com/user-attachments/assets/c9662571-e5c0-4864-8774-c928b12246e0" />

<img width="641" alt="The arrow at the end of a link on the GOV.UK homepage moved below the end of the link text." src="https://github.com/user-attachments/assets/da8f33f0-1932-49e1-8ab5-fb2474abb221" />

I also smuggled in a tiny typo fix.